### PR TITLE
Fix Physics Paper 1b max marks

### DIFF
--- a/src/lib/assets/courses.json
+++ b/src/lib/assets/courses.json
@@ -1777,7 +1777,7 @@
 			},
 			{
 				"name": "Paper 1b",
-				"maxMarks": 25,
+				"maxMarks": 20,
 				"weight": 0.17
 			},
 			{
@@ -1799,7 +1799,7 @@
 			},
 			{
 				"name": "Paper 1b",
-				"maxMarks": 35,
+				"maxMarks": 20,
 				"weight": 0.17
 			},
 			{


### PR DESCRIPTION
## Summary
- set active Physics SL Paper 1b max marks to 20
- set active Physics HL Paper 1b max marks to 20

## Verification
- npm run build
